### PR TITLE
Mastodon plugin update to version 1.4.0

### DIFF
--- a/fp-plugins/mastodon/Function-Organigram.md
+++ b/fp-plugins/mastodon/Function-Organigram.md
@@ -13,75 +13,79 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - The four admin methods `setup()`, `main()`, and `onsubmit()` are implemented at the end of the file inside the `AdminPanelAction` class and are therefore included here.
 - The terms **Entry** and **Comment** follow the wording used by the source code.
 
-## Main organigram / call levels
+## Function count
 
-### 1. Entry points and control flow
+The plugin file currently contains **145** callable functions/methods documented in this organigram:
+- **142** top-level plugin functions
+- **3** admin panel class methods (`setup()`, `main()`, `onsubmit()`)
 
-- `plugin_mastodon_head()`
-  - read plugin options
-  - normalize Mastodon instance URL and configured username
-  - emit `<link rel="me">` and `<meta name="fediverse:creator">` when a username is configured
+## High-level call flow
 
-- `setup()`
-  - `plugin_mastodon_admin_assign()`
+### Frontend and scheduler entry points
 
-- `onsubmit()`
-  - normalize and save configuration
-  - register the OAuth app
-  - exchange the authorization code for an access token
-  - trigger a manual synchronization
-  - `plugin_mastodon_admin_assign()`
+- `plugin_mastodon_head()`  
+  Reads the saved Mastodon configuration, normalizes the instance URL and username, and emits:
+  - `<link rel="me" ...>`
+  - `<meta name="fediverse:creator" ...>`
 
-- `plugin_mastodon_maybe_sync()`
-  - `plugin_mastodon_run_sync()`
-    - `plugin_mastodon_sync_local_to_remote()`
-    - `plugin_mastodon_sync_remote_to_local()`
+- `plugin_mastodon_maybe_sync()`  
+  Calls `plugin_mastodon_sync_due()` and, if due, runs `plugin_mastodon_run_sync()`.
 
-### 2. Local export to Mastodon
+- `plugin_mastodon_run_sync()`  
+  Executes the two main directions in order:
+  1. `plugin_mastodon_sync_local_to_remote()`
+  2. `plugin_mastodon_sync_remote_to_local()`
+
+### Local → remote export path
 
 - `plugin_mastodon_sync_local_to_remote()`
-  - `plugin_mastodon_list_local_entries()`
-  - `plugin_mastodon_build_entry_status_text()`
-  - `plugin_mastodon_collect_local_entry_media()`
-  - `plugin_mastodon_upload_media_items()`
-  - `plugin_mastodon_create_status()`
-  - `plugin_mastodon_update_status()`
-  - `plugin_mastodon_build_comment_status_text()`
-  - `plugin_mastodon_resolve_comment_reply_target()`
+  - loads options and persisted state
+  - retrieves export candidates with `plugin_mastodon_list_local_entries()`
+  - orders entries with `plugin_mastodon_compare_local_entries_for_export()`
+  - builds entry text with `plugin_mastodon_build_entry_status_text()`
+  - collects local images and galleries with `plugin_mastodon_collect_local_entry_media()`
+  - uploads media through `plugin_mastodon_upload_media_items()`
+  - creates or updates Mastodon statuses with `plugin_mastodon_create_status()` / `plugin_mastodon_update_status()`
+  - builds comment replies with `plugin_mastodon_build_comment_status_text()`
+  - resolves reply targets with `plugin_mastodon_resolve_comment_reply_target()`
+  - persists mappings with `plugin_mastodon_state_set_entry_mapping()` and `plugin_mastodon_state_set_comment_mapping()`
 
-### 3. Remote import into FlatPress
+### Remote → local import path
 
 - `plugin_mastodon_sync_remote_to_local()`
-  - `plugin_mastodon_verify_credentials()`
-  - `plugin_mastodon_fetch_account_statuses()`
-  - `plugin_mastodon_import_remote_entry()`
-  - `plugin_mastodon_fetch_status_context()`
-  - `plugin_mastodon_import_remote_context_descendants()`
-  - `plugin_mastodon_import_remote_comment()`
+  - validates credentials with `plugin_mastodon_verify_credentials()`
+  - fetches account statuses with `plugin_mastodon_fetch_account_statuses()`
+  - imports top-level statuses with `plugin_mastodon_import_remote_entry()`
+  - fetches thread context with `plugin_mastodon_fetch_status_context()`
+  - imports replies with `plugin_mastodon_import_remote_context_descendants()`
+  - imports individual replies through `plugin_mastodon_import_remote_comment()`
+  - refreshes known older threads with `plugin_mastodon_collect_known_entry_context_targets()`
 
-### 4. Cross-cutting modules
+### Admin panel flow
 
-- options, secrets, and feature toggles
-- runtime cache, APCu, and persisted state files
-- date/time filters for the synchronization window
-- text, URL, emoji, and BBCode/HTML conversion
-- media handling and file synchronization
-- HTTP, OAuth, and Mastodon API access
+- `setup()` assigns the plugin data for the Smarty view.
+- `main()` keeps the FlatPress admin lifecycle stable.
+- `onsubmit()` handles:
+  - configuration normalization and storage
+  - OAuth app registration
+  - authorization code exchange
+  - manual synchronization
+
 
 ## A. Entry points and admin integration
 
-- `plugin_mastodon_head()` — Emit Mastodon identity metadata into the HTML head when the plugin configuration contains a usable username.
-- `setup()` — Prepare the admin panel and assign Mastodon plugin data to Smarty.
-- `main()` — Return control to the FlatPress admin panel without extra processing.
-- `onsubmit()` — Handle admin form submissions, OAuth actions, configuration saves, and manual synchronization.
-- `plugin_mastodon_admin_assign()` — Assign plugin data to Smarty for the admin panel.
+- `plugin_mastodon_head()` — Print Mastodon profile metadata into the HTML head.
 - `plugin_mastodon_maybe_sync()` — Run the scheduled synchronization when the current request is due.
 - `plugin_mastodon_run_sync()` — Run a full synchronization cycle.
 - `plugin_mastodon_sync_due()` — Determine whether the scheduled synchronization is currently due.
+- `plugin_mastodon_admin_assign()` — Assign plugin data to Smarty for the admin panel.
+- `setup()` — Register the Mastodon admin panel template and assign plugin data to Smarty.
+- `main()` — Keep the admin panel lifecycle compatible with FlatPress without extra processing.
+- `onsubmit()` — Process configuration saves, OAuth actions, and the manual synchronization trigger.
 
 ## B. Defaults, configuration, secrets, and feature toggles
 
-- `plugin_mastodon_default_options()` — Return the default plugin option set.
+- `plugin_mastodon_default_options()` — Return the default plugin option values.
 - `plugin_mastodon_default_state()` — Return the default runtime state structure.
 - `plugin_mastodon_oauth_scopes()` — Return the OAuth scopes requested by the plugin.
 - `plugin_mastodon_get_options()` — Load the saved plugin options and merge them with defaults.
@@ -90,6 +94,10 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_secret_encode()` — Encode a secret value before storing it in the configuration.
 - `plugin_mastodon_secret_decode()` — Decode a previously stored secret value.
 - `plugin_mastodon_normalize_instance_url()` — Normalize the configured Mastodon instance URL.
+- `plugin_mastodon_normalize_head_username()` — Normalize the configured Mastodon username for HTML head metadata.
+- `plugin_mastodon_instance_authority()` — Return the Mastodon instance authority used in fediverse creator metadata.
+- `plugin_mastodon_profile_url()` — Build the public Mastodon profile URL used for the rel-me link.
+- `plugin_mastodon_fediverse_creator_value()` — Build the fediverse creator meta value.
 - `plugin_mastodon_normalize_sync_time()` — Normalize the configured daily sync time.
 - `plugin_mastodon_normalize_sync_start_date()` — Normalize the configured sync start date.
 - `plugin_mastodon_normalize_update_local_from_remote()` — Normalize the toggle that controls whether existing local content may be updated from remote Mastodon data.
@@ -97,7 +105,7 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_normalize_import_synced_comments_as_entries()` — Normalize the toggle that allows importing already synchronized local comments as entries.
 - `plugin_mastodon_should_import_synced_comments_as_entries()` — Check whether a remote Mastodon status that is already mapped to a local FlatPress comment may also be imported as an entry.
 
-## C. Caching, files, logging, and runtime state
+## C. Caching, filesystem helpers, logging, and persisted state
 
 - `plugin_mastodon_runtime_cache_get()` — Return a value from the request-local plugin cache.
 - `plugin_mastodon_runtime_cache_set()` — Store a value in the request-local plugin cache.
@@ -113,14 +121,14 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_log()` — Append a line to the plugin sync log.
 - `plugin_mastodon_state_read()` — Load the persisted runtime state from disk.
 - `plugin_mastodon_state_write()` — Persist the runtime state to disk.
-- `plugin_mastodon_state_normalize()` — Normalize a runtime state array and fill in missing keys.
+- `plugin_mastodon_state_normalize()` —— Normalize a runtime state array and fill in missing keys.
 - `plugin_mastodon_state_comment_key()` — Build the compound state key used for comment mappings.
 - `plugin_mastodon_state_set_entry_mapping()` — Store the mapping between a local entry and a remote status.
 - `plugin_mastodon_state_set_comment_mapping()` — Store the mapping between a local comment and a remote status.
 - `plugin_mastodon_state_get_entry_meta()` — Return mapping metadata for a local entry.
 - `plugin_mastodon_state_get_comment_meta()` — Return mapping metadata for a local comment.
 
-## D. Date, time, and synchronization window helpers
+## D. Date, timestamp, visibility, and threading helpers
 
 - `plugin_mastodon_timestamp_date_key()` — Convert a Unix timestamp into a stable UTC date key.
 - `plugin_mastodon_local_item_date_key()` — Determine the date key of a local FlatPress entry or comment.
@@ -131,9 +139,6 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_parse_iso_datetime()` — Parse an ISO date/time string into FlatPress date format.
 - `plugin_mastodon_parse_iso_timestamp()` — Parse an ISO date/time value into a Unix timestamp.
 - `plugin_mastodon_remote_status_timestamp()` — Resolve the best timestamp for a remote Mastodon status.
-
-## E. Comment threading and remote status eligibility
-
 - `plugin_mastodon_remote_status_visibility()` — Return the normalized visibility of a remote Mastodon status.
 - `plugin_mastodon_remote_status_is_importable()` — Determine whether a remote Mastodon status may be imported.
 - `plugin_mastodon_comment_parent_fields()` — Return the comment fields that may contain a parent reference.
@@ -141,7 +146,7 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_detect_local_comment_parent_id()` — Detect the local parent comment identifier from comment data.
 - `plugin_mastodon_resolve_comment_reply_target()` — Resolve the remote reply target for a local comment export.
 
-## F. Text, URL, language, and format conversion
+## E. Text, URLs, language strings, tags, emojis, and BBCode/HTML conversion
 
 - `plugin_mastodon_guess_subject()` — Guess a subject line from imported plain text.
 - `plugin_mastodon_html_entity_decode()` — Decode HTML entities using the plugin defaults.
@@ -149,6 +154,14 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_extract_url_token()` — Extract the URL token from a BBCode or attribute fragment.
 - `plugin_mastodon_absolute_url()` — Convert a URL or path into an absolute URL when possible.
 - `plugin_mastodon_lang_string()` — Return a localized plugin string or a provided fallback.
+- `plugin_mastodon_tag_plugin_active()` — Determine whether the Tag plugin is active for the current FlatPress request.
+- `plugin_mastodon_normalize_tag_list()` — Normalize a list of tag labels.
+- `plugin_mastodon_extract_flatpress_tags()` — Extract FlatPress Tag plugin labels from an entry body.
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — Remove Tag plugin BBCode blocks from entry content.
+- `plugin_mastodon_mastodon_hashtag_footer()` — Convert FlatPress tag labels into a Mastodon hashtag footer line.
+- `plugin_mastodon_remote_status_tags()` — Collect remote Mastodon tags from a status entity.
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — Remove a trailing Mastodon hashtag footer from imported plain text.
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — Build Tag plugin BBCode from a list of remote Mastodon tags.
 - `plugin_mastodon_emoticon_entity_to_unicode()` — Convert an emoticon HTML entity into a Unicode character.
 - `plugin_mastodon_emoticon_map()` — Return the FlatPress emoticon-to-Unicode lookup map.
 - `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — Replace FlatPress emoticon shortcodes with Unicode glyphs.
@@ -158,113 +171,267 @@ The layout is intentionally hierarchical so responsibilities, call paths, and im
 - `plugin_mastodon_plain_text_from_bbcode()` — Convert FlatPress BBCode into plain text for Mastodon export.
 - `plugin_mastodon_subject_line_is_noise()` — Determine whether an extracted line should be ignored as a subject.
 - `plugin_mastodon_domains_match()` — Determine whether two host names belong to the same domain family.
-- `plugin_mastodon_clean_remote_html()` — Clean imported Mastodon HTML before conversion.
-- `plugin_mastodon_remote_html_to_flatpress()` — Convert Mastodon HTML into FlatPress-oriented text/BBCode.
-- `plugin_mastodon_flatpress_to_mastodon()` — Convert FlatPress content into Mastodon-oriented plain text.
-- `plugin_mastodon_guess_entry_subject()` — Determine the best title for an imported entry.
+- `plugin_mastodon_cleanup_imported_text()` — Clean imported text before saving it to FlatPress.
+- `plugin_mastodon_dom_children_to_flatpress()` — Convert DOM child nodes into FlatPress BBCode text.
+- `plugin_mastodon_dom_node_to_flatpress()` — Convert a single DOM node into FlatPress BBCode text.
+- `plugin_mastodon_public_entry_url()` — Return the public URL for a FlatPress entry.
+- `plugin_mastodon_public_comments_url()` — Return the public comments URL for a FlatPress entry.
+- `plugin_mastodon_public_comment_url()` — Return the public URL for a specific FlatPress comment.
+- `plugin_mastodon_mastodon_html_to_flatpress()` — Convert Mastodon HTML content into FlatPress BBCode.
+- `plugin_mastodon_flatpress_to_mastodon()` — Convert FlatPress content into Mastodon-ready plain text.
+- `plugin_mastodon_limit_text()` — Limit text to a maximum number of characters.
 
-## G. Local content access, media discovery, and hashing
+## F. Local content access, media processing, hashing, and export ordering
 
-- `plugin_mastodon_list_local_entries()` — Return the list of local FlatPress entries that are relevant for export.
-- `plugin_mastodon_entry_file()` — Resolve the path of a local FlatPress entry file.
-- `plugin_mastodon_load_local_entry()` — Load and parse a local FlatPress entry file.
-- `plugin_mastodon_find_comment_file()` — Resolve the path of a local FlatPress comment file.
-- `plugin_mastodon_load_local_comment()` — Load and parse a local FlatPress comment file.
-- `plugin_mastodon_comment_public_url()` — Build the public URL of a local FlatPress comment.
-- `plugin_mastodon_entry_permalink()` — Build the public permalink of a local FlatPress entry.
-- `plugin_mastodon_media_guess_mime_type()` — Determine the MIME type for a local file.
-- `plugin_mastodon_collect_local_entry_media()` — Collect local images and gallery files from an entry body.
-- `plugin_mastodon_build_media_signature()` — Build a stable change signature for the media attached to an entry.
-- `plugin_mastodon_entry_hash()` — Build the local export hash of an entry.
-- `plugin_mastodon_comment_hash()` — Build the local export hash of a comment.
+- `plugin_mastodon_entry_hash()` — Build a change-detection hash for a FlatPress entry.
+- `plugin_mastodon_comment_hash()` — Build a change-detection hash for a FlatPress comment.
+- `plugin_mastodon_safe_path_component()` — Sanitize a string so it can be used as a path component.
+- `plugin_mastodon_safe_filename()` — Sanitize a file name for local storage.
+- `plugin_mastodon_media_relative_to_absolute()` — Resolve a FlatPress media path to an absolute file path.
+- `plugin_mastodon_media_prepare_directory()` — Ensure that a media directory exists.
+- `plugin_mastodon_media_delete_tree()` — Delete a directory tree used for imported media.
+- `plugin_mastodon_media_copy_tree()` — Copy a directory tree used for media synchronization.
+- `plugin_mastodon_bbcode_attr_escape()` — Escape a value for safe BBCode attribute usage.
+- `plugin_mastodon_media_guess_mime_type()` — Guess the MIME type of a local media file.
+- `plugin_mastodon_media_parse_tag_attributes()` — Parse key/value attributes from a FlatPress media tag.
+- `plugin_mastodon_collect_local_entry_media()` — Collect local images referenced by an entry or gallery tag.
+- `plugin_mastodon_entry_media_signature()` — Build a signature for media references contained in entry content.
+- `plugin_mastodon_remote_status_image_attachments()` — Extract image attachments from a remote Mastodon status.
+- `plugin_mastodon_remote_media_source_url()` — Resolve the best downloadable source URL for a remote attachment.
+- `plugin_mastodon_remote_media_description()` — Resolve the best description for a remote attachment.
+- `plugin_mastodon_media_download()` — Download a remote media asset.
+- `plugin_mastodon_build_imported_media_bbcode()` — Build FlatPress BBCode for imported remote media attachments.
+- `plugin_mastodon_collect_entry_files()` — Collect entry files recursively from the FlatPress content tree.
+- `plugin_mastodon_local_item_timestamp()` — Resolve the best timestamp for a local FlatPress item.
+- `plugin_mastodon_compare_local_entries_for_export()` — Compare local FlatPress entries for Mastodon export order.
+- `plugin_mastodon_list_local_entries()` — List local FlatPress entry identifiers.
 
-## H. HTTP, OAuth, Mastodon API, and media transfer
+## G. HTTP transport, OAuth, Mastodon API calls, and media upload
 
-- `plugin_mastodon_http_request()` — Perform an HTTP request against Mastodon or a related file endpoint.
-- `plugin_mastodon_api_url()` — Build an absolute Mastodon API URL from the configured instance URL.
-- `plugin_mastodon_verify_credentials()` — Validate the current access token against Mastodon.
-- `plugin_mastodon_register_app()` — Register the OAuth application on the Mastodon instance.
-- `plugin_mastodon_authorize_url()` — Build the interactive Mastodon authorization URL.
-- `plugin_mastodon_exchange_code()` — Exchange the returned authorization code for an access token.
-- `plugin_mastodon_fetch_account_statuses()` — Fetch account statuses for remote import.
-- `plugin_mastodon_fetch_status_context()` — Fetch the thread context of a Mastodon status.
-- `plugin_mastodon_instance_configuration()` — Fetch and cache Mastodon instance limits and capabilities.
-- `plugin_mastodon_create_status()` — Create a new Mastodon status.
+- `plugin_mastodon_parse_http_response_headers()` — Parse raw HTTP response headers.
+- `plugin_mastodon_stream_context_request()` — Perform an HTTP request through a stream context fallback.
+- `plugin_mastodon_http_build_query()` — Build an application/x-www-form-urlencoded query string.
+- `plugin_mastodon_http_request()` — Perform an HTTP request using cURL or the stream fallback.
+- `plugin_mastodon_mastodon_api()` — Call the Mastodon API and return the raw HTTP response.
+- `plugin_mastodon_mastodon_json()` — Call the Mastodon API and decode a JSON response.
+- `plugin_mastodon_response_error_message()` — Extract the most useful error message from an API response.
+- `plugin_mastodon_register_app()` — Register the FlatPress application on the configured Mastodon instance.
+- `plugin_mastodon_build_authorize_url()` — Build the OAuth authorization URL.
+- `plugin_mastodon_exchange_code_for_token()` — Exchange an OAuth authorization code for an access token.
+- `plugin_mastodon_verify_credentials()` — Verify the currently configured access token.
+- `plugin_mastodon_instance_configuration()` — Load and cache the Mastodon instance configuration document.
+- `plugin_mastodon_instance_media_limit()` — Return the media attachment limit of the configured instance.
+- `plugin_mastodon_instance_media_description_limit()` — Return the media description length limit of the configured instance.
+- `plugin_mastodon_http_request_multipart()` — Perform a multipart HTTP request.
+- `plugin_mastodon_upload_media_items()` — Upload local media items to Mastodon and collect the created media IDs.
+- `plugin_mastodon_instance_character_limit()` — Return the status character limit of the configured instance.
+- `plugin_mastodon_fetch_account_statuses()` — Fetch statuses for the authenticated Mastodon account.
+- `plugin_mastodon_fetch_status_context()` — Fetch the conversation context for a Mastodon status.
+- `plugin_mastodon_create_status()` — Create a Mastodon status.
 - `plugin_mastodon_update_status()` — Update an existing Mastodon status.
-- `plugin_mastodon_upload_media_file()` — Upload one local media file to Mastodon.
-- `plugin_mastodon_upload_media_items()` — Upload multiple local media files and return their media IDs.
-- `plugin_mastodon_download_remote_media()` — Download remote Mastodon media into FlatPress storage.
 
-## I. Import and export builders
+## H. Import/export builders and synchronization orchestration
 
-- `plugin_mastodon_build_entry_status_text()` — Build the exported Mastodon text for a FlatPress entry.
-- `plugin_mastodon_build_comment_status_text()` — Build the exported Mastodon text for a FlatPress comment.
-- `plugin_mastodon_import_remote_entry()` — Import one Mastodon status as a FlatPress entry.
-- `plugin_mastodon_import_remote_comment()` — Import one Mastodon reply as a FlatPress comment.
-- `plugin_mastodon_import_remote_context_descendants()` — Import reply descendants from a Mastodon thread context.
-- `plugin_mastodon_import_known_entry_contexts()` — Refresh already known remote entry contexts to detect newly added replies on older threads.
+- `plugin_mastodon_build_entry_status_text()` — Build the status body used when exporting a FlatPress entry.
+- `plugin_mastodon_build_comment_status_text()` — Build the status body used when exporting a FlatPress comment.
+- `plugin_mastodon_import_remote_entry()` — Import a remote Mastodon status into FlatPress as an entry.
+- `plugin_mastodon_import_remote_comment()` — Import a remote Mastodon reply into FlatPress as a comment.
+- `plugin_mastodon_import_remote_context_descendants()` — Import remote Mastodon replies from a fetched thread context.
+- `plugin_mastodon_collect_known_entry_context_targets()` — Collect known synchronized entry threads that should have their Mastodon reply context refreshed.
+- `plugin_mastodon_sync_remote_to_local()` — Synchronize remote Mastodon content into FlatPress.
+- `plugin_mastodon_sync_local_to_remote()` — Synchronize local FlatPress content to Mastodon.
 
-## J. Synchronization orchestration
+## Recommended reading order for new developers
 
-- `plugin_mastodon_sync_local_to_remote()` — Export local FlatPress entries and comments to Mastodon.
-- `plugin_mastodon_sync_remote_to_local()` — Import Mastodon statuses and replies into FlatPress.
-
-## K. Admin panel class methods
-
-- `setup()` — Register the plugin panel, load data, and prepare the UI state.
-- `main()` — Keep the admin panel lifecycle compatible with FlatPress.
-- `onsubmit()` — Process all form actions, configuration updates, OAuth actions, and manual sync triggers.
-
-## Developer reading order
-
-For new developers, this reading order is usually the quickest way to understand the plugin:
+A practical way to understand the plugin is:
 
 1. `plugin_mastodon_run_sync()`
 2. `plugin_mastodon_sync_local_to_remote()`
 3. `plugin_mastodon_sync_remote_to_local()`
-4. `plugin_mastodon_import_remote_entry()`
-5. `plugin_mastodon_import_remote_comment()`
-6. `plugin_mastodon_build_entry_status_text()`
-7. `plugin_mastodon_build_comment_status_text()`
-8. `plugin_mastodon_state_read()` and `plugin_mastodon_state_write()`
+4. `plugin_mastodon_build_entry_status_text()`
+5. `plugin_mastodon_build_comment_status_text()`
+6. `plugin_mastodon_import_remote_entry()`
+7. `plugin_mastodon_import_remote_comment()`
+8. `plugin_mastodon_state_read()` / `plugin_mastodon_state_write()`
 9. `plugin_mastodon_get_options()`
 10. `plugin_mastodon_http_request()`
+11. `plugin_mastodon_collect_local_entry_media()`
+12. `plugin_mastodon_instance_configuration()`
 
-## Practical architecture summary
+## Current feature areas reflected in the function set
 
-The plugin consists of five major layers:
+The plugin includes dedicated function groups for:
 
-1. **Admin and scheduling layer**  
-   Configuration, OAuth actions, manual sync, scheduled sync.
-
-2. **Synchronization orchestration layer**  
-   Decides when and how local and remote content is processed.
-
-3. **Transformation layer**  
-   Converts FlatPress text, BBCode, emojis, URLs, and media references into Mastodon format and back.
-
-4. **Persistence and mapping layer**  
-   Stores configuration, secrets, runtime state, mapping metadata, and sync history.
-
-5. **Transport layer**  
-   Handles HTTP, OAuth, Mastodon API endpoints, media uploads, and media downloads.
-
-## Frontend head metadata note
-
-The frontend head integration is intentionally small and configuration-driven:
-
-- it should only run on frontend output, not inside the admin panel
-- it should stay read-only and must not trigger synchronization
-- it depends on the configured Mastodon instance URL and username
-- if no username is configured, the function should emit nothing
-- usernames entered without a leading `@` should still produce:
-  - a profile URL such as `https://mastodon.url/@username`
-  - a creator value such as `@username@mastodon.url`
+- Mastodon identity metadata in the HTML head
+- runtime cache and optional APCu-backed shared cache
+- encrypted storage of sensitive configuration values
+- sync start date filtering
+- optional remote overwrite of existing local content
+- optional import of already synchronized comments as entries
+- tag synchronization through the FlatPress Tag plugin BBCode
+- emoji conversion between FlatPress-style shortcodes and Mastodon-style Unicode
+- bidirectional media synchronization for entry images and galleries
+- old-thread reply refresh during remote import
+- explicit export ordering so older local entries are posted before newer ones
 
 ## Maintenance notes
 
-- Changes to entry or comment mapping usually affect both sync directions.
-- Changes to text conversion should be tested for entries, comments, emojis, links, and media placeholders.
-- Changes to date logic should be tested with the sync start date and with already synchronized older threads.
-- Changes to media handling should be tested with single images, galleries, missing files, and limited Mastodon scopes.
-- Changes to runtime state should always be checked against `state.json`, log output, and repeated sync runs.
+When changing the plugin, these clusters usually need to stay in sync:
+
+- **configuration + admin UI + normalization helpers**
+- **state mappings + import/export code**
+- **text conversion + media conversion + hashtag handling**
+- **date filters + scheduling + known-thread refresh**
+- **HTTP transport + OAuth + instance capability caching**
+
+A change in one of these areas often requires corresponding updates in the simulation script.
+
+## Alphabetical appendix
+
+The following appendix lists every function once more in alphabetical order for quick lookup.
+
+- `main()` — line 4372
+- `onsubmit()` — line 4376
+- `plugin_mastodon_absolute_url()` — line 1259
+- `plugin_mastodon_admin_assign()` — line 4335
+- `plugin_mastodon_apcu_cache_key()` — line 214
+- `plugin_mastodon_apcu_delete()` — line 258
+- `plugin_mastodon_apcu_enabled()` — line 205
+- `plugin_mastodon_apcu_fetch()` — line 228
+- `plugin_mastodon_apcu_store()` — line 245
+- `plugin_mastodon_bbcode_attr_escape()` — line 2399
+- `plugin_mastodon_blog_base_url()` — line 1203
+- `plugin_mastodon_build_authorize_url()` — line 3487
+- `plugin_mastodon_build_comment_status_text()` — line 3729
+- `plugin_mastodon_build_entry_status_text()` — line 3662
+- `plugin_mastodon_build_flatpress_tag_bbcode()` — line 1523
+- `plugin_mastodon_build_imported_media_bbcode()` — line 2691
+- `plugin_mastodon_cleanup_imported_text()` — line 1763
+- `plugin_mastodon_collect_entry_files()` — line 3043
+- `plugin_mastodon_collect_known_entry_context_targets()` — line 4022
+- `plugin_mastodon_collect_local_entry_media()` — line 2478
+- `plugin_mastodon_comment_hash()` — line 2259
+- `plugin_mastodon_comment_parent_fields()` — line 1082
+- `plugin_mastodon_compare_local_entries_for_export()` — line 3100
+- `plugin_mastodon_create_status()` — line 3626
+- `plugin_mastodon_date_matches_sync_start()` — line 768
+- `plugin_mastodon_default_options()` — line 86
+- `plugin_mastodon_default_state()` — line 107
+- `plugin_mastodon_detect_local_comment_parent_id()` — line 1108
+- `plugin_mastodon_dom_children_to_flatpress()` — line 1817
+- `plugin_mastodon_dom_node_to_flatpress()` — line 1835
+- `plugin_mastodon_domains_match()` — line 1749
+- `plugin_mastodon_emoticon_entity_to_unicode()` — line 1537
+- `plugin_mastodon_emoticon_map()` — line 1550
+- `plugin_mastodon_ensure_state_dir()` — line 805
+- `plugin_mastodon_entry_hash()` — line 2247
+- `plugin_mastodon_entry_media_signature()` — line 2601
+- `plugin_mastodon_exchange_code_for_token()` — line 3507
+- `plugin_mastodon_extract_flatpress_tags()` — line 1366
+- `plugin_mastodon_extract_url_token()` — line 1242
+- `plugin_mastodon_fediverse_creator_value()` — line 559
+- `plugin_mastodon_fetch_account_statuses()` — line 3566
+- `plugin_mastodon_fetch_status_context()` — line 3613
+- `plugin_mastodon_file_prestat()` — line 271
+- `plugin_mastodon_file_prestat_signature()` — line 291
+- `plugin_mastodon_flatpress_to_mastodon()` — line 2110
+- `plugin_mastodon_get_options()` — line 302
+- `plugin_mastodon_guess_subject()` — line 1152
+- `plugin_mastodon_head()` — line 577
+- `plugin_mastodon_html_entity_decode()` — line 1194
+- `plugin_mastodon_http_build_query()` — line 3227
+- `plugin_mastodon_http_request()` — line 3264
+- `plugin_mastodon_http_request_multipart()` — line 2847
+- `plugin_mastodon_import_remote_comment()` — line 3866
+- `plugin_mastodon_import_remote_context_descendants()` — line 3938
+- `plugin_mastodon_import_remote_entry()` — line 3766
+- `plugin_mastodon_instance_authority()` — line 513
+- `plugin_mastodon_instance_character_limit()` — line 3551
+- `plugin_mastodon_instance_configuration()` — line 2788
+- `plugin_mastodon_instance_media_description_limit()` — line 2831
+- `plugin_mastodon_instance_media_limit()` — line 2818
+- `plugin_mastodon_is_public_host()` — line 1637
+- `plugin_mastodon_lang_string()` — line 1301
+- `plugin_mastodon_limit_text()` — line 2225
+- `plugin_mastodon_list_local_entries()` — line 3118
+- `plugin_mastodon_local_item_date_key()` — line 721
+- `plugin_mastodon_local_item_matches_sync_start()` — line 787
+- `plugin_mastodon_local_item_timestamp()` — line 3074
+- `plugin_mastodon_log()` — line 814
+- `plugin_mastodon_mastodon_api()` — line 3377
+- `plugin_mastodon_mastodon_hashtag_footer()` — line 1408
+- `plugin_mastodon_mastodon_html_to_flatpress()` — line 2008
+- `plugin_mastodon_mastodon_json()` — line 3421
+- `plugin_mastodon_maybe_sync()` — line 4319
+- `plugin_mastodon_media_copy_tree()` — line 2361
+- `plugin_mastodon_media_delete_tree()` — line 2334
+- `plugin_mastodon_media_download()` — line 2679
+- `plugin_mastodon_media_guess_mime_type()` — line 2411
+- `plugin_mastodon_media_parse_tag_attributes()` — line 2447
+- `plugin_mastodon_media_prepare_directory()` — line 2318
+- `plugin_mastodon_media_relative_to_absolute()` — line 2305
+- `plugin_mastodon_normalize_comment_parent_id()` — line 1091
+- `plugin_mastodon_normalize_head_username()` — line 474
+- `plugin_mastodon_normalize_import_synced_comments_as_entries()` — line 682
+- `plugin_mastodon_normalize_instance_url()` — line 441
+- `plugin_mastodon_normalize_sync_start_date()` — line 631
+- `plugin_mastodon_normalize_sync_time()` — line 613
+- `plugin_mastodon_normalize_tag_list()` — line 1335
+- `plugin_mastodon_normalize_update_local_from_remote()` — line 657
+- `plugin_mastodon_oauth_scopes()` — line 133
+- `plugin_mastodon_parse_http_response_headers()` — line 3155
+- `plugin_mastodon_parse_iso_datetime()` — line 998
+- `plugin_mastodon_parse_iso_timestamp()` — line 1016
+- `plugin_mastodon_plain_text_from_bbcode()` — line 1679
+- `plugin_mastodon_profile_url()` — line 543
+- `plugin_mastodon_public_comment_url()` — line 1993
+- `plugin_mastodon_public_comments_url()` — line 1965
+- `plugin_mastodon_public_entry_url()` — line 1938
+- `plugin_mastodon_public_url_for_mastodon()` — line 1660
+- `plugin_mastodon_register_app()` — line 3465
+- `plugin_mastodon_remote_media_description()` — line 2664
+- `plugin_mastodon_remote_media_source_url()` — line 2650
+- `plugin_mastodon_remote_status_date_key()` — line 741
+- `plugin_mastodon_remote_status_image_attachments()` — line 2627
+- `plugin_mastodon_remote_status_is_importable()` — line 1070
+- `plugin_mastodon_remote_status_matches_sync_start()` — line 797
+- `plugin_mastodon_remote_status_tags()` — line 1429
+- `plugin_mastodon_remote_status_timestamp()` — line 1038
+- `plugin_mastodon_remote_status_visibility()` — line 1057
+- `plugin_mastodon_replace_emoticon_shortcodes_with_unicode()` — line 1604
+- `plugin_mastodon_replace_unicode_emoticons_with_shortcodes()` — line 1615
+- `plugin_mastodon_resolve_comment_reply_target()` — line 1130
+- `plugin_mastodon_response_error_message()` — line 3436
+- `plugin_mastodon_run_sync()` — line 4261
+- `plugin_mastodon_runtime_cache_clear()` — line 190
+- `plugin_mastodon_runtime_cache_get()` — line 144
+- `plugin_mastodon_runtime_cache_set()` — line 172
+- `plugin_mastodon_safe_filename()` — line 2292
+- `plugin_mastodon_safe_path_component()` — line 2277
+- `plugin_mastodon_save_options()` — line 333
+- `plugin_mastodon_secret_decode()` — line 410
+- `plugin_mastodon_secret_encode()` — line 387
+- `plugin_mastodon_secret_key()` — line 367
+- `plugin_mastodon_should_import_synced_comments_as_entries()` — line 698
+- `plugin_mastodon_should_update_local_from_remote()` — line 673
+- `plugin_mastodon_state_comment_key()` — line 908
+- `plugin_mastodon_state_get_comment_meta()` — line 988
+- `plugin_mastodon_state_get_entry_meta()` — line 976
+- `plugin_mastodon_state_normalize()` — line 890
+- `plugin_mastodon_state_read()` — line 824
+- `plugin_mastodon_state_set_comment_mapping()` — line 951
+- `plugin_mastodon_state_set_entry_mapping()` — line 923
+- `plugin_mastodon_state_write()` — line 866
+- `plugin_mastodon_stream_context_request()` — line 3188
+- `plugin_mastodon_strip_flatpress_tag_bbcode()` — line 1391
+- `plugin_mastodon_strip_trailing_mastodon_hashtag_footer()` — line 1456
+- `plugin_mastodon_subject_line_is_noise()` — line 1721
+- `plugin_mastodon_sync_due()` — line 4239
+- `plugin_mastodon_sync_local_to_remote()` — line 4112
+- `plugin_mastodon_sync_remote_to_local()` — line 4056
+- `plugin_mastodon_tag_plugin_active()` — line 1325
+- `plugin_mastodon_timestamp_date_key()` — line 707
+- `plugin_mastodon_update_status()` — line 3646
+- `plugin_mastodon_upload_media_items()` — line 2978
+- `plugin_mastodon_verify_credentials()` — line 3534
+- `setup()` — line 4367

--- a/fp-plugins/mastodon/README.md
+++ b/fp-plugins/mastodon/README.md
@@ -12,6 +12,10 @@ The plugin synchronizes FlatPress content with one Mastodon account in **both di
 
 The plugin also synchronizes **images** for FlatPress entries and Mastodon statuses.
 
+When the FlatPress **Tag** plugin is active, the plugin also synchronizes **entry tags** in both directions:
+- FlatPress entry tags -> Mastodon hashtags
+- Mastodon hashtags -> FlatPress entry tags
+
 ## Important concept
 
 Mastodon does not have a separate “comment” object in the way a blog does. In practice, comments are represented as **replies**.
@@ -28,7 +32,7 @@ The plugin works with the following mapping:
 
 You need:
 
-- a working FlatPress 1.5 Stringendo installation
+- a working FlatPress 1.5.1 Stringendo installation
 - PHP **7.2 to 8.5**
 - the plugin files from this package
 
@@ -41,6 +45,12 @@ The code uses these PHP features and transports:
 - **JSON**
 - **DOMDocument / libxml** for best HTML-to-BBCode conversion
 - **OpenSSL** to encrypt stored secrets when available
+
+### Optional FlatPress plugin for tag synchronization ###
+
+If you want to synchronize entry tags between FlatPress and Mastodon, also enable:
+
+- the FlatPress **Tag** plugin
 
 ### Recommended but not strictly required
 
@@ -85,6 +95,17 @@ You will see a Mastodon post as a **FlatPress comment** when it is a reply insid
 - There is also a **Run synchronization now** button in the admin panel
 
 In simple words: if nobody visits your FlatPress site after the scheduled time, the automatic sync will wait until the next normal page request.
+
+### Tag support
+
+- Tag synchronization works only when the FlatPress **Tag** plugin is active.
+- FlatPress **entries** can export tags to Mastodon.
+- FlatPress **comments** do not support tags and therefore do not export tags.
+- Mastodon top-level statuses can import hashtags into FlatPress entries.
+- Mastodon replies imported as FlatPress comments do not get tags.
+- FlatPress tags are synchronized to Mastodon as **hashtags** with a leading `#`.
+- Mastodon hashtags are synchronized to FlatPress **without** the leading `#`.
+- If tags are removed on FlatPress or on Mastodon, the next synchronization updates the other side accordingly.
 
 ### Media support
 
@@ -283,6 +304,16 @@ If a FlatPress comment contains a valid parent comment reference, it is exported
 
 This keeps reply chains threaded on Mastodon.
 
+### Tag export
+
+When the FlatPress **Tag** plugin is active, the plugin reads the local entry tags and appends them to the exported Mastodon entry:
+
+- on a **new line**
+- at the **end** of the Mastodon entry
+- as Mastodon **hashtags** with a leading `#`
+- If no tags exist, no hashtag line is added.
+- If tags were removed from the FlatPress entry, the next update of the already synchronized Mastodon status removes that hashtag line again.
+
 ### Image export
 
 For FlatPress entries, the plugin detects:
@@ -314,6 +345,7 @@ The imported FlatPress entry contains:
 - the Mastodon author name
 - the Mastodon timestamp
 - a footer link back to Mastodon
+- synchronized tags from the Mastodon status, when the FlatPress **Tag** plugin is active
 
 ### Comment import
 
@@ -322,6 +354,15 @@ Replies from the imported Mastodon thread are imported as FlatPress comments.
 The plugin reads the thread context of the imported top-level status and imports descendant replies.
 
 If a reply is itself a reply to another reply, the plugin stores the local parent relation with `replyto`, so the reply structure is preserved in data.
+
+### Tag import ===
+
+When the FlatPress **Tag** plugin is active, the plugin imports Mastodon hashtags into the FlatPress entry:
+
+- Mastodon hashtags are stored as FlatPress entry tags
+- the leading `#` is removed
+- only entry imports use tags; imported comments do not
+- If tags were removed from the Mastodon status, the next allowed update of the synchronized FlatPress entry removes the corresponding local tags again.
 
 ### Image import
 
@@ -408,6 +449,15 @@ Then check:
 
 - `fp-content/mastodon/sync.log`
 - the counters in the plugin admin page
+
+### Tags are missing or not updated
+
+Check these points:
+
+- Is the FlatPress **Tag** plugin enabled?
+- Are you synchronizing an **entry** and not a comment?
+- Were the tags removed on one side and has a new sync already been run?
+- Is the option to update existing local content from Mastodon enabled when you expect remote tag deletions or remote tag changes to update an already imported FlatPress entry?
 
 ### Images are missing on Mastodon
 

--- a/fp-plugins/mastodon/doc_mastodon.txt
+++ b/fp-plugins/mastodon/doc_mastodon.txt
@@ -1,5 +1,6 @@
 ====== FlatPress Mastodon Plugin User Guide ======
 
+Author: [[https://frank-web.dedyn.io|Fraenkiman]]
 ===== What this plugin does =====
 
 The plugin synchronizes FlatPress content with one Mastodon account in **both directions**:
@@ -11,6 +12,11 @@ The plugin synchronizes FlatPress content with one Mastodon account in **both di
   * Mastodon reply inside the imported thread -> FlatPress comment
 
 The plugin also synchronizes **images** for FlatPress entries and Mastodon statuses.
+
+When the FlatPress **Tag** plugin is active, the plugin also synchronizes **entry tags** in both directions:
+
+  * FlatPress entry tags -> Mastodon hashtags
+  * Mastodon hashtags -> FlatPress entry tags
 
 ===== Important concept =====
 
@@ -28,7 +34,7 @@ The plugin works with the following mapping:
 
 You need:
 
-  * a working FlatPress 1.5 Stringendo installation
+  * a working FlatPress 1.5.1 Stringendo installation
   * PHP **7.2 to 8.5**
   * the plugin files from this package
 
@@ -42,6 +48,12 @@ The code uses these PHP features and transports:
   * **DOMDocument / libxml** for best HTML-to-BBCode conversion
   * **OpenSSL** to encrypt stored secrets when available
 
+==== Optional FlatPress plugin for tag synchronization ====
+
+If you want to synchronize entry tags between FlatPress and Mastodon, also enable:
+
+  * the FlatPress **Tag** plugin
+
 ==== Recommended but not strictly required ====
 
   * **OpenSSL enabled**
@@ -52,8 +64,6 @@ The code uses these PHP features and transports:
     * If your FlatPress site only runs on ''localhost'', Mastodon readers cannot open your blog links from the fediverse.
 
 ===== Current limitations and behavior =====
-
-These points come directly from the plugin code.
 
 ==== Visibility and privacy ====
 
@@ -88,6 +98,17 @@ You will see a Mastodon post as a **FlatPress comment** when it is a reply insid
 
 In simple words: if nobody visits your FlatPress site after the scheduled time, the automatic sync will wait until the next normal page request.
 
+==== Tag support ====
+
+  * Tag synchronization works only when the FlatPress **Tag** plugin is active.
+  * FlatPress **entries** can export tags to Mastodon.
+  * FlatPress **comments** do not support tags and therefore do not export tags.
+  * Mastodon top-level statuses can import hashtags into FlatPress entries.
+  * Mastodon replies imported as FlatPress comments do not get tags.
+  * FlatPress tags are synchronized to Mastodon as **hashtags** with a leading ''#''.
+  * Mastodon hashtags are synchronized to FlatPress **without** the leading ''#''.
+  * If tags are removed on FlatPress or on Mastodon, the next synchronization updates the other side accordingly.
+
 ==== Media support ====
 
   * FlatPress **entries** can export images from ''[img]'' and ''[gallery]''
@@ -114,7 +135,7 @@ That means:
 
 ===== Files to install =====
 
-Copy these items from the plugin package into your FlatPress installation:
+Copy these items from [[res:plugins:mastodon#download|the plugin package]] into your FlatPress installation:
 
   * ''fp-plugins/mastodon/''
 
@@ -156,7 +177,6 @@ Do **not** use something like:
 
   * ''https://mastodon.social/@yourname''
   * ''https://mastodon.social/web/statuses/1234567890''
-
 
 ===== Step 2: Save the basic settings =====
 
@@ -285,6 +305,18 @@ If a FlatPress comment contains a valid parent comment reference, it is exported
 
 This keeps reply chains threaded on Mastodon.
 
+=== Tag export ===
+
+When the FlatPress **Tag** plugin is active, the plugin reads the local entry tags and appends them to the exported Mastodon entry:
+
+  * on a **new line**
+  * at the **end** of the Mastodon entry
+  * as Mastodon **hashtags** with a leading ''#''
+
+If no tags exist, no hashtag line is added.
+
+If tags were removed from the FlatPress entry, the next update of the already synchronized Mastodon status removes that hashtag line again.
+
 === Image export ===
 
 For FlatPress entries, the plugin detects:
@@ -316,6 +348,7 @@ The imported FlatPress entry contains:
   * the Mastodon author name
   * the Mastodon timestamp
   * a footer link back to Mastodon
+  * synchronized tags from the Mastodon status, when the FlatPress **Tag** plugin is active
 
 === Comment import ===
 
@@ -324,6 +357,16 @@ Replies from the imported Mastodon thread are imported as FlatPress comments.
 The plugin reads the thread context of the imported top-level status and imports descendant replies.
 
 If a reply is itself a reply to another reply, the plugin stores the local parent relation with ''replyto'', so the reply structure is preserved in data.
+
+=== Tag import ===
+
+When the FlatPress **Tag** plugin is active, the plugin imports Mastodon hashtags into the FlatPress entry:
+
+  * Mastodon hashtags are stored as FlatPress entry tags
+  * the leading ''#'' is removed
+  * only entry imports use tags; imported comments do not
+
+If tags were removed from the Mastodon status, the next allowed update of the synchronized FlatPress entry removes the corresponding local tags again.
 
 === Image import ===
 
@@ -341,6 +384,8 @@ If image descriptions exist on Mastodon, the plugin saves them as gallery captio
 ===== When you will see a Mastodon post as a FlatPress entry or comment =====
 
 ==== You will see it as a FlatPress entry when: ====
+
+**Tip of the day:**\\ Mastodon limits posts to a maximum of 500 characters. If your FlatPress posts and comments are longer than 500 characters and you want to keep them that way, disable the "//Update existing local content from Mastodon//" option.
 
   * it is a top-level status of the connected Mastodon account
   * it is fetched from the account status timeline
@@ -420,6 +465,15 @@ Check these points:
   * Does the stored token include permission to upload media?
   * Does your Mastodon server allow the image count and file type?
 
+==== Tags are missing or not updated ====
+
+Check these points:
+
+  * Is the FlatPress **Tag** plugin enabled?
+  * Are you synchronizing an **entry** and not a comment?
+  * Were the tags removed on one side and has a new sync already been run?
+  * Is the option to update existing local content from Mastodon enabled when you expect remote tag deletions or remote tag changes to update an already imported FlatPress entry?
+
 ==== Imported Mastodon images are missing in FlatPress ====
 
 Check these points:
@@ -447,3 +501,6 @@ The safest order is:
   - run a manual sync
   - check ''last sync'', ''last error'', and ''sync.log''
   - only then rely on the automatic daily sync
+
+===== License =====
+The plugin's code is licensed under the FlatPress Project License.

--- a/fp-plugins/mastodon/plugin.mastodon.php
+++ b/fp-plugins/mastodon/plugin.mastodon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mastodon
  * Plugin URI: https://frank-web.dedyn.io
  * Description: Synchronizes FlatPress entries and comments with Mastodon. <a href="./fp-plugins/mastodon/doc_mastodon.txt" title="Instructions" target="_blank">[Instructions]</a>
- * Version: 1.3.0
+ * Version: 1.4.0
  * Author: Fraenkiman
  * Author URI: https://frank-web.dedyn.io
  */
@@ -621,7 +621,6 @@ function plugin_mastodon_normalize_sync_time($time) {
 	}
 	return str_pad((string) $hour, 2, '0', STR_PAD_LEFT) . ':' . str_pad((string) $minute, 2, '0', STR_PAD_LEFT);
 }
-
 
 /**
  * Normalize the configured sync start date.
@@ -1315,6 +1314,221 @@ function plugin_mastodon_lang_string($key, $default) {
 }
 
 /**
+ * Determine whether the Tag plugin is active for the current FlatPress request.
+ *
+ * The Tag plugin exposes entry tags through [tag]...[/tag] BBCode and updates its
+ * tag database on the publish_post hook. The Mastodon plugin only syncs tags when
+ * the Tag plugin is actually active, otherwise entry content stays untouched.
+ *
+ * @return bool
+ */
+function plugin_mastodon_tag_plugin_active() {
+	return class_exists('plugin_tag_entry') && isset($GLOBALS ['plugin_tag']) && is_object($GLOBALS ['plugin_tag']);
+}
+
+/**
+ * Normalize a list of tag labels.
+ *
+ * @param array<int, string> $tags
+ * @return array<int, string>
+ */
+function plugin_mastodon_normalize_tag_list($tags) {
+	$normalized = array();
+	$seen = array();
+
+	foreach ((array) $tags as $tag) {
+		$tag = trim((string) $tag);
+		$tag = ltrim($tag, "# \t\n\r\0\x0B");
+		if ($tag === '') {
+			continue;
+		}
+		$key = function_exists('mb_strtolower') ? mb_strtolower($tag, 'UTF-8') : strtolower($tag);
+		if (isset($seen [$key])) {
+			continue;
+		}
+		$seen [$key] = true;
+		$normalized [] = $tag;
+	}
+
+	return $normalized;
+}
+
+/**
+ * Extract FlatPress Tag plugin labels from an entry body.
+ *
+ * The Tag plugin stores tags inside [tag]...[/tag] BBCode blocks. Each block
+ * contains a comma-separated list. The same semantics are used here so export
+ * and import match the Tag plugin's own publish_post processing.
+ *
+ * @param string $content
+ * @return array<int, string>
+ */
+function plugin_mastodon_extract_flatpress_tags($content) {
+	$content = (string) $content;
+	if ($content === '' || stripos($content, '[tag') === false) {
+		return array();
+	}
+
+	$tags = array();
+	if (preg_match_all('!\[tag\](.*?)\[/tag\]!is', $content, $matches) && !empty($matches[1])) {
+		foreach ($matches [1] as $tagGroup) {
+			$parts = explode(',', (string) $tagGroup);
+			foreach ($parts as $part) {
+				$tags [] = (string) $part;
+			}
+		}
+	}
+
+	return plugin_mastodon_normalize_tag_list($tags);
+}
+
+/**
+ * Remove Tag plugin BBCode blocks from entry content.
+ *
+ * @param string $content
+ * @return string
+ */
+function plugin_mastodon_strip_flatpress_tag_bbcode($content) {
+	$content = preg_replace('!\n?\[tag\].*?\[/tag\]\n?!is', "\n", (string) $content);
+	$content = str_replace(array("\r\n", "\r"), "\n", (string) $content);
+	$content = preg_replace("/\n{3,}/", "\n\n", (string) $content);
+	return trim((string) $content);
+}
+
+/**
+ * Convert FlatPress tag labels into a Mastodon hashtag footer line.
+ *
+ * Mastodon exposes status tags as strings without the leading hash sign, while
+ * the visible status text uses #hashtag tokens. Local FlatPress tags are therefore
+ * normalized into safe hashtag tokens and emitted as a single footer line.
+ *
+ * @param array<int, string> $tags
+ * @return string
+ */
+function plugin_mastodon_mastodon_hashtag_footer($tags) {
+	$tokens = array();
+
+	foreach (plugin_mastodon_normalize_tag_list($tags) as $tag) {
+		$token = preg_replace('/\s+/u', '', $tag);
+		$token = trim((string) $token);
+		if ($token === '') {
+			continue;
+		}
+		$tokens [] = '#' . $token;
+	}
+
+	return trim(implode(' ', array_unique($tokens)));
+}
+
+/**
+ * Collect remote Mastodon tags from a status entity.
+ *
+ * @param array<string, mixed> $remoteStatus
+ * @return array<int, string>
+ */
+function plugin_mastodon_remote_status_tags($remoteStatus) {
+	$tags = array();
+
+	if (!empty($remoteStatus ['tags']) && is_array($remoteStatus ['tags'])) {
+		foreach ($remoteStatus ['tags'] as $remoteTag) {
+			if (is_array($remoteTag) && !empty($remoteTag ['name'])) {
+				$tags [] = (string) $remoteTag ['name'];
+			} elseif (is_string($remoteTag)) {
+				$tags [] = $remoteTag;
+			}
+		}
+	}
+
+	return plugin_mastodon_normalize_tag_list($tags);
+}
+
+/**
+ * Remove a trailing Mastodon hashtag footer from imported plain text.
+ *
+ * Exported FlatPress tags are appended as a dedicated hashtag line. When such a
+ * status is imported back, that trailing hashtag-only line is converted back into
+ * Tag plugin metadata instead of staying visible in the FlatPress entry body.
+ *
+ * @param string $content
+ * @param array<int, string> $remoteTags
+ * @return string
+ */
+function plugin_mastodon_strip_trailing_mastodon_hashtag_footer($content, $remoteTags) {
+	$content = trim((string) $content);
+	$remoteTags = plugin_mastodon_normalize_tag_list($remoteTags);
+	if ($content === '' || empty($remoteTags)) {
+		return $content;
+	}
+
+	$normalizedRemote = array();
+	foreach ($remoteTags as $tag) {
+		$key = function_exists('mb_strtolower') ? mb_strtolower($tag, 'UTF-8') : strtolower($tag);
+		$normalizedRemote [$key] = true;
+	}
+
+	$lines = preg_split("/\r\n|\r|\n/", $content);
+	if (!is_array($lines) || empty($lines)) {
+		return $content;
+	}
+
+	$index = count($lines) - 1;
+	while ($index >= 0 && trim((string) $lines [$index]) === '') {
+		$index--;
+	}
+	if ($index < 0) {
+		return '';
+	}
+
+	$footerLine = trim((string) $lines [$index]);
+	if ($footerLine === '') {
+		return $content;
+	}
+
+	$tokens = preg_split('/\s+/u', $footerLine);
+	if (!is_array($tokens) || empty($tokens)) {
+		return $content;
+	}
+
+	$matched = array();
+	foreach ($tokens as $token) {
+		$token = trim((string) $token);
+		if ($token === '' || strpos($token, '#') !== 0) {
+			return $content;
+		}
+		$token = ltrim($token, '#');
+		if ($token === '') {
+			return $content;
+		}
+		$key = function_exists('mb_strtolower') ? mb_strtolower($token, 'UTF-8') : strtolower($token);
+		if (!isset($normalizedRemote [$key])) {
+			return $content;
+		}
+		$matched [$key] = true;
+	}
+
+	if (empty($matched)) {
+		return $content;
+	}
+
+	array_splice($lines, $index, 1);
+	return trim((string) preg_replace("/\n{3,}/", "\n\n", implode("\n", $lines)));
+}
+
+/**
+ * Build Tag plugin BBCode from a list of remote Mastodon tags.
+ *
+ * @param array<int, string> $tags
+ * @return string
+ */
+function plugin_mastodon_build_flatpress_tag_bbcode($tags) {
+	$tags = plugin_mastodon_normalize_tag_list($tags);
+	if (empty($tags)) {
+		return '';
+	}
+	return '[tag]' . implode(', ', $tags) . '[/tag]';
+}
+
+/**
  * Convert an emoticon HTML entity into a Unicode character.
  * @param string $value
  * @return string
@@ -1896,6 +2110,9 @@ function plugin_mastodon_flatpress_to_mastodon($text) {
 	$text = plugin_mastodon_replace_emoticon_shortcodes_with_unicode((string) $text);
 	if ($text === '') {
 		return '';
+	}
+	if (plugin_mastodon_tag_plugin_active()) {
+		$text = plugin_mastodon_strip_flatpress_tag_bbcode($text);
 	}
 
 	$text = preg_replace_callback(
@@ -3458,6 +3675,36 @@ function plugin_mastodon_build_entry_status_text($entryId, $entry, $charLimit) {
 
 	$text = trim(implode("\n\n", $parts));
 	$link = plugin_mastodon_public_url_for_mastodon(plugin_mastodon_public_entry_url($entryId, $entry));
+	$hashtags = '';
+	if (plugin_mastodon_tag_plugin_active()) {
+		$hashtags = plugin_mastodon_mastodon_hashtag_footer(plugin_mastodon_extract_flatpress_tags($content));
+	}
+
+	if ($hashtags !== '') {
+		$suffixParts = array();
+		if ($link !== '') {
+			$suffixParts [] = $link;
+		}
+		$suffixParts [] = $hashtags;
+		$suffix = implode("\n", $suffixParts);
+		$suffixLength = function_exists('mb_strlen') ? mb_strlen($suffix, 'UTF-8') : strlen($suffix);
+		$separatorLength = $text !== '' ? 1 : 0;
+		$available = $charLimit - $separatorLength - $suffixLength;
+		if ($available >= 32) {
+			$text = trim((string) plugin_mastodon_limit_text($text, $available));
+			$text = $text === '' ? $suffix : $text . "\n" . $suffix;
+			return trim((string) $text);
+		}
+
+		$suffixLength = function_exists('mb_strlen') ? mb_strlen($hashtags, 'UTF-8') : strlen($hashtags);
+		$available = $charLimit - $separatorLength - $suffixLength;
+		if ($available >= 32) {
+			$text = trim((string) plugin_mastodon_limit_text($text, $available));
+			$text = $text === '' ? $hashtags : $text . "\n" . $hashtags;
+			return trim((string) $text);
+		}
+	}
+
 	if ($link !== '') {
 		$available = $charLimit - 1 - (function_exists('mb_strlen') ? mb_strlen($link, 'UTF-8') : strlen($link));
 		if ($available < 32) {
@@ -3527,6 +3774,10 @@ function plugin_mastodon_import_remote_entry(&$options, &$state, $remoteStatus) 
 	}
 
 	$content = plugin_mastodon_mastodon_html_to_flatpress(isset($remoteStatus ['content']) ? $remoteStatus ['content'] : '');
+	$remoteTags = plugin_mastodon_remote_status_tags($remoteStatus);
+	if (plugin_mastodon_tag_plugin_active()) {
+		$content = plugin_mastodon_strip_trailing_mastodon_hashtag_footer($content, $remoteTags);
+	}
 	$mediaBbcode = plugin_mastodon_build_imported_media_bbcode($options, $remoteStatus);
 	if ($mediaBbcode !== '') {
 		$content = trim($content . $mediaBbcode);
@@ -3549,6 +3800,12 @@ function plugin_mastodon_import_remote_entry(&$options, &$state, $remoteStatus) 
 		$footer = "[url=" . $url . ']Mastodon[/url]';
 	}
 	$entryContent = trim((string) $content);
+	if (plugin_mastodon_tag_plugin_active()) {
+		$tagBbcode = plugin_mastodon_build_flatpress_tag_bbcode($remoteTags);
+		if ($tagBbcode !== '') {
+			$entryContent = $entryContent === '' ? $tagBbcode : $entryContent . "\n\n" . $tagBbcode;
+		}
+	}
 	if ($footer !== '') {
 		$entryContent = $entryContent === '' ? $footer : $entryContent . "\n" . $footer;
 	}


### PR DESCRIPTION
- Added bidirectional synchronization of entry tags when the FlatPress Tag plugin is active.
- FlatPress entry tags are exported to Mastodon as hashtags in a new line at the end of the status.
- Mastodon hashtags are imported into FlatPress entries without the leading hash sign.
- Tag deletions are synchronized in both directions.